### PR TITLE
Fix id placeholder

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -72,7 +72,7 @@ class KmipEngine(object):
         * Cryptographic usage mask enforcement per object type
     """
 
-    def __init__(self, policies=None, database_path=None):
+    def __init__(self, policies=None, database_path=None, logger=None):
         """
         Create a KmipEngine.
 
@@ -84,7 +84,7 @@ class KmipEngine(object):
                 used to store all server data. Optional, defaults to None.
                 If none, database path defaults to '/tmp/pykmip.database'.
         """
-        self._logger = logging.getLogger('kmip.server.engine')
+        self._logger = logger
 
         self._cryptography_engine = engine.CryptographyEngine()
 
@@ -354,6 +354,7 @@ class KmipEngine(object):
 
     def _process_batch(self, request_batch, batch_handling, batch_order):
         response_batch = list()
+        self._id_placeholder = None
 
         with self._data_store_session_factory() as session:
             self._data_session = session
@@ -2466,6 +2467,9 @@ class KmipEngine(object):
         response_payload = payloads.LocateResponsePayload(
             unique_identifiers=unique_identifiers
         )
+
+        if len(managed_objects) == 1:
+            self._id_placeholder = str(managed_objects[0].unique_identifier)
 
         return response_payload
 

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -261,7 +261,8 @@ class KmipServer(object):
 
         self._engine = engine.KmipEngine(
             policies=self.policies,
-            database_path=self.config.settings.get('database_path')
+            database_path=self.config.settings.get('database_path'),
+            logger = self._logger
         )
 
         self._logger.info("Starting server socket handler.")


### PR DESCRIPTION
According to the [KMIP docs](https://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html#_Toc490660849):
> The key management server SHALL implement a temporary variable called the ID Placeholder. This value consists of a single Unique Identifier. It is a variable stored inside the server that is only valid and preserved during the execution of a batch of operations. Once the batch of operations has been completed, the ID Placeholder value SHALL be discarded and/or invalidated by the server, so that subsequent requests do not find this previous ID Placeholder available.

Thus I set the `self._id_placeholder = None` in each batch request. That value was shared between different batch requests.

And regarding the **LOCATE** operation:
> If a single Unique Identifier is returned to the client, then the server SHALL copy the Unique Identifier returned by this operation into the ID Placeholder variable.
 
Thus now when locate finds an object it sets the `_id_placeholder` to the id of that object.

--- 

Additionally I decided to pass the logger from server to the engine, as only the server one was set to save logs to the log file.